### PR TITLE
docs: highlight breaking changes in v1.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 # AGENTS
 
 - Write all code comments, documentation, commit messages, and changelog entries in English.
+- Record every project change in `CHANGELOG.md` under a new version `X.Y.Z` (the exact number is assigned at release).
 - For the platform philosophy behind this library, see [PHILOSOPHY.md](./PHILOSOPHY.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 - Added AGENTS.md with English-only guidelines and link to PHILOSOPHY.md.
 - Switched tests from Mocha to Node's built-in runner.
 - Updated package scripts and removed Mocha dependency.
+- Documented breaking changes for v1.0.0: the container can no longer access itself, configuration must occur in the Composition Root, and legacy versions live in the `forerunner` branch.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ![npms.io](https://img.shields.io/npm/dm/@teqfw/di)
 ![jsdelivr](https://img.shields.io/jsdelivr/npm/hm/@teqfw/di)
 
+> [!IMPORTANT]
+> **Breaking Changes in v1.0.0**
+>
+> The library has been stable for a long time and is now promoted to its first major version. To improve security, the Object Container can no longer access itself, so all configuration must occur in the Composition Root. This restriction ensures that third-party plugins cannot override or modify the container's internal functionality. Legacy versions are maintained in the `forerunner` branch, and packages like `@teqfw/core` should depend on `@teqfw/di` versions below `1.0.0`.
+
 `@teqfw/di` is a lightweight dependency injection container for standard JavaScript, enabling late binding of code
 objects with minimal manual configuration. It integrates smoothly in both browser and Node.js environments, supporting
 flexibility, modularity, and easier testing for your applications.


### PR DESCRIPTION
## Summary
- document breaking changes for v1.0.0, including restricted container access and legacy `forerunner` branch
- require documenting all project changes in CHANGELOG via AGENTS instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70623b100832d98870d563b538c87