### PR TITLE
chore: prepare npm package for rollup build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.github/
+test/
+doc/
+rollup.config.js
+eslint.config.js
+*.log
+!dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## X.Y.Z
+- Prepare npm package for publication.
+- Add distribution build outputs to package files and specify entry points.
+
 ## 1.0.0
 - Started changelog for version 1.0.0.
 - Added AGENTS.md with English-only guidelines and link to PHILOSOPHY.md.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,20 @@
     "email": "alex@flancer64.com",
     "url": "https://github.com/flancer64"
   },
-  "main": "src/Container.js",
+  "files": [
+    "dist/",
+    "src/",
+    "LICENSE",
+    "README.md"
+  ],
+  "main": "dist/umd.js",
+  "module": "dist/esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm.js",
+      "require": "./dist/umd.js"
+    }
+  },
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add `files`, `main`, `module` and `exports` fields to prepare for publishing built artifacts
- exclude development files from npm package via `.npmignore`
- document package publishing changes in changelog

## Testing
- `npm test`
- `npm run rollup`
- `npm pack`

------
https://chatgpt.com/codex/tasks/task_e_68a711e639c8832d93809e1b9aabfb27