### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,8 @@
 name: npm publication
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/teqfw/di/security/code-scanning/4](https://github.com/teqfw/di/security/code-scanning/4)

In general, the fix is to declare an explicit `permissions:` block that grants only the minimum required scopes to the `GITHUB_TOKEN`. For a typical npm publish workflow that only needs to read repository contents and does not use `GITHUB_TOKEN` for write operations, `contents: read` is sufficient. If later steps start using GitHub APIs that require more privileges, they can be added explicitly.

The best fix here, without changing existing functionality, is to add a root-level `permissions:` block (so it applies to all jobs) just under the `name:` and before `on:`. This will restrict `GITHUB_TOKEN` to read-only access to repo contents for both `build` and `publish-npm`. Since the npm publish uses `NODE_AUTH_TOKEN` from `secrets.npm_token`, no extra GitHub permissions are needed. No additional imports, methods, or other definitions are required—only the YAML change in `.github/workflows/npm-publish.yml`.

Concretely, in `.github/workflows/npm-publish.yml`, add:

```yaml
permissions:
  contents: read
```

after line 1 (`name: npm publication`) and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
